### PR TITLE
PR: Add Manifest Files for Integration of Scoop Bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ See original discussion: [wezterm/wezterm#2396](https://github.com/wezterm/wezte
 First installation:
 
 ```sh
-scoop bucket add wezterm-alt-icon https://github.com/noidilin/wezterm-alt-icon.git
+scoop bucket add wezterm-alt-icon https://github.com/ocodo/wezterm-alt-windows-icon-builds.git
 scoop install wezterm-alt-icon/wezterm-mikker-black
 ```
 

--- a/bucket/wezterm-gf3-darkbrite-deux.json
+++ b/bucket/wezterm-gf3-darkbrite-deux.json
@@ -1,0 +1,41 @@
+{
+    "version": "20240203-110809-5046fc22-alt-icons",
+    "description": "GPU-accelerated terminal emulator (Gf3-Darkbrite-deux alternative icon build)",
+    "homepage": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
+    "license": "Apache-2.0",
+    "notes": [
+        "This is one of the alternative icons build created by @ocodo",
+        "The icon is created by @gf3",
+        "You can find other builds that apply different icon in the repo"
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/20240203-110809-5046fc22-alt-icons/WezTerm-windows-Gf3-Darkbrite-deux-20240203-110809-5046fc22.zip",
+            "hash": "7cf6604063204451f73c5c14ad5a5e4bf9bf260f79dd103670d51d00c072137a"
+        }
+    },
+    "bin": [
+        "wezterm.exe",
+        "wezterm-gui.exe"
+    ],
+    "shortcuts": [
+        [
+            "wezterm-gui.exe",
+            "Wezterm (Gf3-Darkbrite-deux)"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
+        "regex": "wezterm-Gf3-Darkbrite-deux-([\\w-]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Gf3-Darkbrite-deux-$version.zip"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/wezterm-gf3-darkbrite-deux.json
+++ b/bucket/wezterm-gf3-darkbrite-deux.json
@@ -26,12 +26,12 @@
     ],
     "checkver": {
         "github": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
-        "regex": "wezterm-Gf3-Darkbrite-deux-([\\w-]+)"
+        "regex": "tag/(([\\w-]+)-alt-icons)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Gf3-Darkbrite-deux-$version.zip"
+                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Gf3-Darkbrite-deux-$match1.zip"
             }
         },
         "hash": {

--- a/bucket/wezterm-gf3-darkbrite-une.json
+++ b/bucket/wezterm-gf3-darkbrite-une.json
@@ -1,0 +1,41 @@
+{
+    "version": "20240203-110809-5046fc22-alt-icons",
+    "description": "GPU-accelerated terminal emulator (Gf3-Darkbrite-une alternative icon build)",
+    "homepage": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
+    "license": "Apache-2.0",
+    "notes": [
+        "This is one of the alternative icons build created by @ocodo",
+        "The icon is created by @gf3",
+        "You can find other builds that apply different icon in the repo"
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/20240203-110809-5046fc22-alt-icons/WezTerm-windows-Gf3-Darkbrite-une-20240203-110809-5046fc22.zip",
+            "hash": "36e543d41537c4f46161d8bd6405cd7289565fe1256ea14124c2a2275a88fa95"
+        }
+    },
+    "bin": [
+        "wezterm.exe",
+        "wezterm-gui.exe"
+    ],
+    "shortcuts": [
+        [
+            "wezterm-gui.exe",
+            "Wezterm (Gf3-Darkbrite-une)"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
+        "regex": "wezterm-Gf3-Darkbrite-une-([\\w-]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Gf3-Darkbrite-une-$version.zip"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/wezterm-gf3-darkbrite-une.json
+++ b/bucket/wezterm-gf3-darkbrite-une.json
@@ -26,12 +26,12 @@
     ],
     "checkver": {
         "github": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
-        "regex": "wezterm-Gf3-Darkbrite-une-([\\w-]+)"
+        "regex": "tag/(([\\w-]+)-alt-icons)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Gf3-Darkbrite-une-$version.zip"
+                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Gf3-Darkbrite-une-$match1.zip"
             }
         },
         "hash": {

--- a/bucket/wezterm-gf3-darksoft-deux.json
+++ b/bucket/wezterm-gf3-darksoft-deux.json
@@ -1,0 +1,41 @@
+{
+    "version": "20240203-110809-5046fc22-alt-icons",
+    "description": "GPU-accelerated terminal emulator (Gf3-Darksoft-deux alternative icon build)",
+    "homepage": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
+    "license": "Apache-2.0",
+    "notes": [
+        "This is one of the alternative icons build created by @ocodo",
+        "The icon is created by @gf3",
+        "You can find other builds that apply different icon in the repo"
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/20240203-110809-5046fc22-alt-icons/WezTerm-windows-Gf3-Darksoft-deux-20240203-110809-5046fc22.zip",
+            "hash": "72d735871b17981483a6bc1a1d9ed707cef5ba759439b73fe8cf1eef3c62ef9c"
+        }
+    },
+    "bin": [
+        "wezterm.exe",
+        "wezterm-gui.exe"
+    ],
+    "shortcuts": [
+        [
+            "wezterm-gui.exe",
+            "Wezterm (Gf3-Darksoft-deux)"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
+        "regex": "wezterm-Gf3-Darksoft-deux-([\\w-]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Gf3-Darksoft-deux-$version.zip"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/wezterm-gf3-darksoft-deux.json
+++ b/bucket/wezterm-gf3-darksoft-deux.json
@@ -26,12 +26,12 @@
     ],
     "checkver": {
         "github": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
-        "regex": "wezterm-Gf3-Darksoft-deux-([\\w-]+)"
+        "regex": "tag/(([\\w-]+)-alt-icons)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Gf3-Darksoft-deux-$version.zip"
+                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Gf3-Darksoft-deux-$match1.zip"
             }
         },
         "hash": {

--- a/bucket/wezterm-gf3-darksoft-une.json
+++ b/bucket/wezterm-gf3-darksoft-une.json
@@ -1,0 +1,41 @@
+{
+    "version": "20240203-110809-5046fc22-alt-icons",
+    "description": "GPU-accelerated terminal emulator (Gf3-Darksoft-une alternative icon build)",
+    "homepage": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
+    "license": "Apache-2.0",
+    "notes": [
+        "This is one of the alternative icons build created by @ocodo",
+        "The icon is created by @gf3",
+        "You can find other builds that apply different icon in the repo"
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/20240203-110809-5046fc22-alt-icons/WezTerm-windows-Gf3-Darksoft-une-20240203-110809-5046fc22.zip",
+            "hash": "076b22e3da9e3a51301682cc71f7d431e4d132bd8ec2c9b413ae3b0739d683bd"
+        }
+    },
+    "bin": [
+        "wezterm.exe",
+        "wezterm-gui.exe"
+    ],
+    "shortcuts": [
+        [
+            "wezterm-gui.exe",
+            "Wezterm (Gf3-Darksoft-une)"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
+        "regex": "wezterm-Gf3-Darksoft-une-([\\w-]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Gf3-Darksoft-une-$version.zip"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/wezterm-gf3-darksoft-une.json
+++ b/bucket/wezterm-gf3-darksoft-une.json
@@ -26,12 +26,12 @@
     ],
     "checkver": {
         "github": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
-        "regex": "wezterm-Gf3-Darksoft-une-([\\w-]+)"
+        "regex": "tag/(([\\w-]+)-alt-icons)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Gf3-Darksoft-une-$version.zip"
+                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Gf3-Darksoft-une-$match1.zip"
             }
         },
         "hash": {

--- a/bucket/wezterm-gf3-darkultra-nueng.json
+++ b/bucket/wezterm-gf3-darkultra-nueng.json
@@ -1,0 +1,41 @@
+{
+    "version": "20240203-110809-5046fc22-alt-icons",
+    "description": "GPU-accelerated terminal emulator (Gf3-Darkultra-nueng alternative icon build)",
+    "homepage": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
+    "license": "Apache-2.0",
+    "notes": [
+        "This is one of the alternative icons build created by @ocodo",
+        "The icon is created by @gf3",
+        "You can find other builds that apply different icon in the repo"
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/20240203-110809-5046fc22-alt-icons/WezTerm-windows-Gf3-Darkultra-nueng-20240203-110809-5046fc22.zip",
+            "hash": "d8cdec7ce1ad5854b6dc0ef7bbe39dc79e03ff02d8e0d9046cf0b9677d6bed0e"
+        }
+    },
+    "bin": [
+        "wezterm.exe",
+        "wezterm-gui.exe"
+    ],
+    "shortcuts": [
+        [
+            "wezterm-gui.exe",
+            "Wezterm (Gf3-Darkultra-nueng)"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
+        "regex": "wezterm-Gf3-Darkultra-nueng-([\\w-]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Gf3-Darkultra-nueng-$version.zip"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/wezterm-gf3-darkultra-nueng.json
+++ b/bucket/wezterm-gf3-darkultra-nueng.json
@@ -26,12 +26,12 @@
     ],
     "checkver": {
         "github": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
-        "regex": "wezterm-Gf3-Darkultra-nueng-([\\w-]+)"
+        "regex": "tag/(([\\w-]+)-alt-icons)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Gf3-Darkultra-nueng-$version.zip"
+                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Gf3-Darkultra-nueng-$match1.zip"
             }
         },
         "hash": {

--- a/bucket/wezterm-gf3-darkultra-sam.json
+++ b/bucket/wezterm-gf3-darkultra-sam.json
@@ -1,0 +1,41 @@
+{
+    "version": "20240203-110809-5046fc22-alt-icons",
+    "description": "GPU-accelerated terminal emulator (Gf3-Darkultra-sam alternative icon build)",
+    "homepage": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
+    "license": "Apache-2.0",
+    "notes": [
+        "This is one of the alternative icons build created by @ocodo",
+        "The icon is created by @gf3",
+        "You can find other builds that apply different icon in the repo"
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/20240203-110809-5046fc22-alt-icons/WezTerm-windows-Gf3-Darkultra-sam-20240203-110809-5046fc22.zip",
+            "hash": "597234bb999505142b94bb45eefddac0eb382c3eb9a2c1b4350a98d4609a7cee"
+        }
+    },
+    "bin": [
+        "wezterm.exe",
+        "wezterm-gui.exe"
+    ],
+    "shortcuts": [
+        [
+            "wezterm-gui.exe",
+            "Wezterm (Gf3-Darkultra-sam)"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
+        "regex": "wezterm-Gf3-Darkultra-sam-([\\w-]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Gf3-Darkultra-sam-$version.zip"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/wezterm-gf3-darkultra-sam.json
+++ b/bucket/wezterm-gf3-darkultra-sam.json
@@ -26,12 +26,12 @@
     ],
     "checkver": {
         "github": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
-        "regex": "wezterm-Gf3-Darkultra-sam-([\\w-]+)"
+        "regex": "tag/(([\\w-]+)-alt-icons)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Gf3-Darkultra-sam-$version.zip"
+                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Gf3-Darkultra-sam-$match1.zip"
             }
         },
         "hash": {

--- a/bucket/wezterm-gf3-darkultra-song.json
+++ b/bucket/wezterm-gf3-darkultra-song.json
@@ -1,0 +1,41 @@
+{
+    "version": "20240203-110809-5046fc22-alt-icons",
+    "description": "GPU-accelerated terminal emulator (Gf3-Darkultra-song alternative icon build)",
+    "homepage": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
+    "license": "Apache-2.0",
+    "notes": [
+        "This is one of the alternative icons build created by @ocodo",
+        "The icon is created by @gf3",
+        "You can find other builds that apply different icon in the repo"
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/20240203-110809-5046fc22-alt-icons/WezTerm-windows-Gf3-Darkultra-song-20240203-110809-5046fc22.zip",
+            "hash": "f0871d021672ef525e132fd9a00e60d7c0e5adcb0a0d070d5aa116fdd1c2657b"
+        }
+    },
+    "bin": [
+        "wezterm.exe",
+        "wezterm-gui.exe"
+    ],
+    "shortcuts": [
+        [
+            "wezterm-gui.exe",
+            "Wezterm (Gf3-Darkultra-song)"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
+        "regex": "wezterm-Gf3-Darkultra-song-([\\w-]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Gf3-Darkultra-song-$version.zip"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/wezterm-gf3-darkultra-song.json
+++ b/bucket/wezterm-gf3-darkultra-song.json
@@ -26,12 +26,12 @@
     ],
     "checkver": {
         "github": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
-        "regex": "wezterm-Gf3-Darkultra-song-([\\w-]+)"
+        "regex": "tag/(([\\w-]+)-alt-icons)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Gf3-Darkultra-song-$version.zip"
+                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Gf3-Darkultra-song-$match1.zip"
             }
         },
         "hash": {

--- a/bucket/wezterm-gf3-shine.json
+++ b/bucket/wezterm-gf3-shine.json
@@ -1,0 +1,41 @@
+{
+    "version": "20240203-110809-5046fc22-alt-icons",
+    "description": "GPU-accelerated terminal emulator (Gf3-Shine alternative icon build)",
+    "homepage": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
+    "license": "Apache-2.0",
+    "notes": [
+        "This is one of the alternative icons build created by @ocodo",
+        "The icon is created by @gf3",
+        "You can find other builds that apply different icon in the repo"
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/20240203-110809-5046fc22-alt-icons/WezTerm-windows-Gf3-Shine-20240203-110809-5046fc22.zip",
+            "hash": "6e76be702a15d78d39d80dfc67a36513138a25c08bd439cef05f2c695780fa21"
+        }
+    },
+    "bin": [
+        "wezterm.exe",
+        "wezterm-gui.exe"
+    ],
+    "shortcuts": [
+        [
+            "wezterm-gui.exe",
+            "Wezterm (Gf3-Shine)"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
+        "regex": "wezterm-Gf3-Shine-([\\w-]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Gf3-Shine-$version.zip"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/wezterm-gf3-shine.json
+++ b/bucket/wezterm-gf3-shine.json
@@ -26,12 +26,12 @@
     ],
     "checkver": {
         "github": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
-        "regex": "wezterm-Gf3-Shine-([\\w-]+)"
+        "regex": "tag/(([\\w-]+)-alt-icons)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Gf3-Shine-$version.zip"
+                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Gf3-Shine-$match1.zip"
             }
         },
         "hash": {

--- a/bucket/wezterm-gf3-ultrabrite.json
+++ b/bucket/wezterm-gf3-ultrabrite.json
@@ -1,0 +1,41 @@
+{
+    "version": "20240203-110809-5046fc22-alt-icons",
+    "description": "GPU-accelerated terminal emulator (Gf3-Ultrabrite alternative icon build)",
+    "homepage": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
+    "license": "Apache-2.0",
+    "notes": [
+        "This is one of the alternative icons build created by @ocodo",
+        "The icon is created by @gf3",
+        "You can find other builds that apply different icon in the repo"
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/20240203-110809-5046fc22-alt-icons/WezTerm-windows-Gf3-Ultrabrite-20240203-110809-5046fc22.zip",
+            "hash": "e8e3eaf20a13802e9b90b0dc4bad5a0eb20d69434656881f8cd8c544f4da1c98"
+        }
+    },
+    "bin": [
+        "wezterm.exe",
+        "wezterm-gui.exe"
+    ],
+    "shortcuts": [
+        [
+            "wezterm-gui.exe",
+            "Wezterm (Gf3-Ultrabrite)"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
+        "regex": "wezterm-Gf3-Ultrabrite-([\\w-]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Gf3-Ultrabrite-$version.zip"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/wezterm-gf3-ultrabrite.json
+++ b/bucket/wezterm-gf3-ultrabrite.json
@@ -26,12 +26,12 @@
     ],
     "checkver": {
         "github": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
-        "regex": "wezterm-Gf3-Ultrabrite-([\\w-]+)"
+        "regex": "tag/(([\\w-]+)-alt-icons)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Gf3-Ultrabrite-$version.zip"
+                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Gf3-Ultrabrite-$match1.zip"
             }
         },
         "hash": {

--- a/bucket/wezterm-grapao-base.json
+++ b/bucket/wezterm-grapao-base.json
@@ -1,0 +1,41 @@
+{
+    "version": "20240203-110809-5046fc22-alt-icons",
+    "description": "GPU-accelerated terminal emulator (Grapao-Base alternative icon build)",
+    "homepage": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
+    "license": "Apache-2.0",
+    "notes": [
+        "This is one of the alternative icons build created by @ocodo",
+        "The icon is created by @grapao",
+        "You can find other builds that apply different icon in the repo"
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/20240203-110809-5046fc22-alt-icons/WezTerm-windows-Grapao-Base-20240203-110809-5046fc22.zip",
+            "hash": "d37981c56e98c6a4c3f020f85b4f9dda4f583cb78e79af3d265c0ada7df59145"
+        }
+    },
+    "bin": [
+        "wezterm.exe",
+        "wezterm-gui.exe"
+    ],
+    "shortcuts": [
+        [
+            "wezterm-gui.exe",
+            "Wezterm (Grapao-Base)"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
+        "regex": "wezterm-Grapao-Base-([\\w-]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Grapao-Base-$version.zip"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/wezterm-grapao-base.json
+++ b/bucket/wezterm-grapao-base.json
@@ -26,12 +26,12 @@
     ],
     "checkver": {
         "github": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
-        "regex": "wezterm-Grapao-Base-([\\w-]+)"
+        "regex": "tag/(([\\w-]+)-alt-icons)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Grapao-Base-$version.zip"
+                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Grapao-Base-$match1.zip"
             }
         },
         "hash": {

--- a/bucket/wezterm-grapao-forest.json
+++ b/bucket/wezterm-grapao-forest.json
@@ -1,0 +1,41 @@
+{
+    "version": "20240203-110809-5046fc22-alt-icons",
+    "description": "GPU-accelerated terminal emulator (Grapao-Forest alternative icon build)",
+    "homepage": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
+    "license": "Apache-2.0",
+    "notes": [
+        "This is one of the alternative icons build created by @ocodo",
+        "The icon is created by @grapao",
+        "You can find other builds that apply different icon in the repo"
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/20240203-110809-5046fc22-alt-icons/WezTerm-windows-Grapao-Forest-20240203-110809-5046fc22.zip",
+            "hash": "ca542a8d2ccb6a39cb424ec090f420eb5c4ed691271e69fadfc3b1eb9ef51578"
+        }
+    },
+    "bin": [
+        "wezterm.exe",
+        "wezterm-gui.exe"
+    ],
+    "shortcuts": [
+        [
+            "wezterm-gui.exe",
+            "Wezterm (Grapao-Forest)"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
+        "regex": "wezterm-Grapao-Forest-([\\w-]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Grapao-Forest-$version.zip"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/wezterm-grapao-forest.json
+++ b/bucket/wezterm-grapao-forest.json
@@ -26,12 +26,12 @@
     ],
     "checkver": {
         "github": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
-        "regex": "wezterm-Grapao-Forest-([\\w-]+)"
+        "regex": "tag/(([\\w-]+)-alt-icons)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Grapao-Forest-$version.zip"
+                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Grapao-Forest-$match1.zip"
             }
         },
         "hash": {

--- a/bucket/wezterm-grapao-green.json
+++ b/bucket/wezterm-grapao-green.json
@@ -1,0 +1,41 @@
+{
+    "version": "20240203-110809-5046fc22-alt-icons",
+    "description": "GPU-accelerated terminal emulator (Grapao-Green alternative icon build)",
+    "homepage": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
+    "license": "Apache-2.0",
+    "notes": [
+        "This is one of the alternative icons build created by @ocodo",
+        "The icon is created by @grapao",
+        "You can find other builds that apply different icon in the repo"
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/20240203-110809-5046fc22-alt-icons/WezTerm-windows-Grapao-Green-20240203-110809-5046fc22.zip",
+            "hash": "7fe4a772c2c2bf43d7bf6237dda019646f4aab129a020d2cdb119dd157626f4a"
+        }
+    },
+    "bin": [
+        "wezterm.exe",
+        "wezterm-gui.exe"
+    ],
+    "shortcuts": [
+        [
+            "wezterm-gui.exe",
+            "Wezterm (Grapao-Green)"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
+        "regex": "wezterm-Grapao-Green-([\\w-]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Grapao-Green-$version.zip"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/wezterm-grapao-green.json
+++ b/bucket/wezterm-grapao-green.json
@@ -26,12 +26,12 @@
     ],
     "checkver": {
         "github": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
-        "regex": "wezterm-Grapao-Green-([\\w-]+)"
+        "regex": "tag/(([\\w-]+)-alt-icons)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Grapao-Green-$version.zip"
+                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Grapao-Green-$match1.zip"
             }
         },
         "hash": {

--- a/bucket/wezterm-grapao-original-style.json
+++ b/bucket/wezterm-grapao-original-style.json
@@ -1,0 +1,41 @@
+{
+    "version": "20240203-110809-5046fc22-alt-icons",
+    "description": "GPU-accelerated terminal emulator (Original-Style alternative icon build)",
+    "homepage": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
+    "license": "Apache-2.0",
+    "notes": [
+        "This is one of the alternative icons build created by @ocodo",
+        "The icon is created by @grapao",
+        "You can find other builds that apply different icon in the repo"
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/20240203-110809-5046fc22-alt-icons/WezTerm-windows-Grapao-Original-Style-20240203-110809-5046fc22.zip",
+            "hash": "b4638628bbd5dd7526bea5d53019ced7120b718ce63ce86cc496f42de02d83ad"
+        }
+    },
+    "bin": [
+        "wezterm.exe",
+        "wezterm-gui.exe"
+    ],
+    "shortcuts": [
+        [
+            "wezterm-gui.exe",
+            "Wezterm (Original-Style)"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
+        "regex": "wezterm-Original-Style-([\\w-]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Original-Style-$version.zip"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/wezterm-grapao-original-style.json
+++ b/bucket/wezterm-grapao-original-style.json
@@ -26,12 +26,12 @@
     ],
     "checkver": {
         "github": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
-        "regex": "wezterm-Original-Style-([\\w-]+)"
+        "regex": "tag/(([\\w-]+)-alt-icons)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Original-Style-$version.zip"
+                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Grapao-Original-Style-$match1.zip"
             }
         },
         "hash": {

--- a/bucket/wezterm-grapao-pastel.json
+++ b/bucket/wezterm-grapao-pastel.json
@@ -1,0 +1,41 @@
+{
+    "version": "20240203-110809-5046fc22-alt-icons",
+    "description": "GPU-accelerated terminal emulator (Grapao-Pastel alternative icon build)",
+    "homepage": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
+    "license": "Apache-2.0",
+    "notes": [
+        "This is one of the alternative icons build created by @ocodo",
+        "The icon is created by @grapao",
+        "You can find other builds that apply different icon in the repo"
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/20240203-110809-5046fc22-alt-icons/WezTerm-windows-Grapao-Pastel-20240203-110809-5046fc22.zip",
+            "hash": "f50548439b51262635baf6eb636262bd66b1f2876b3984aa94af7efb5815d8ec"
+        }
+    },
+    "bin": [
+        "wezterm.exe",
+        "wezterm-gui.exe"
+    ],
+    "shortcuts": [
+        [
+            "wezterm-gui.exe",
+            "Wezterm (Grapao-Pastel)"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
+        "regex": "wezterm-Grapao-Pastel-([\\w-]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Grapao-Pastel-$version.zip"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/wezterm-grapao-pastel.json
+++ b/bucket/wezterm-grapao-pastel.json
@@ -26,12 +26,12 @@
     ],
     "checkver": {
         "github": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
-        "regex": "wezterm-Grapao-Pastel-([\\w-]+)"
+        "regex": "tag/(([\\w-]+)-alt-icons)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Grapao-Pastel-$version.zip"
+                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Grapao-Pastel-$match1.zip"
             }
         },
         "hash": {

--- a/bucket/wezterm-mikker-black.json
+++ b/bucket/wezterm-mikker-black.json
@@ -1,0 +1,41 @@
+{
+    "version": "20240203-110809-5046fc22-alt-icons",
+    "description": "GPU-accelerated terminal emulator (Mikker-Black alternative icon build)",
+    "homepage": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
+    "license": "Apache-2.0",
+    "notes": [
+        "This is one of the alternative icons build created by @ocodo",
+        "The icon is created by @mikker",
+        "You can find other builds that apply different icon in the repo"
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/20240203-110809-5046fc22-alt-icons/WezTerm-windows-Mikker-Black-20240203-110809-5046fc22.zip",
+            "hash": "730431d9b0dba7c1f4d6b64f2128897b66f2c88533d88d932e29d5c0fc8fe7fe"
+        }
+    },
+    "bin": [
+        "wezterm.exe",
+        "wezterm-gui.exe"
+    ],
+    "shortcuts": [
+        [
+            "wezterm-gui.exe",
+            "Wezterm (Mikker-Black)"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
+        "regex": "wezterm-Mikker-Black-([\\w-]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Mikker-Black-$version.zip"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/wezterm-mikker-black.json
+++ b/bucket/wezterm-mikker-black.json
@@ -26,12 +26,12 @@
     ],
     "checkver": {
         "github": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
-        "regex": "wezterm-Mikker-Black-([\\w-]+)"
+        "regex": "tag/(([\\w-]+)-alt-icons)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Mikker-Black-$version.zip"
+                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Mikker-Black-$match1.zip"
             }
         },
         "hash": {

--- a/bucket/wezterm.json
+++ b/bucket/wezterm.json
@@ -1,0 +1,41 @@
+{
+    "version": "20240203-110809-5046fc22-alt-icons",
+    "description": "GPU-accelerated terminal emulator (Mikker-Black alternative icon build)",
+    "homepage": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
+    "license": "Apache-2.0",
+    "notes": [
+        "This is one of the alternative icons build created by @ocodo",
+        "The icon is created by @mikker",
+        "You can find other builds that apply different icon in the repo"
+    ],
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/20240203-110809-5046fc22-alt-icons/WezTerm-windows-Mikker-Black-20240203-110809-5046fc22.zip",
+            "hash": "730431d9b0dba7c1f4d6b64f2128897b66f2c88533d88d932e29d5c0fc8fe7fe"
+        }
+    },
+    "bin": [
+        "wezterm.exe",
+        "wezterm-gui.exe"
+    ],
+    "shortcuts": [
+        [
+            "wezterm-gui.exe",
+            "Wezterm (Mikker-Black)"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
+        "regex": "wezterm-Mikker-Black-([\\w-]+)"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Mikker-Black-$version.zip"
+            }
+        },
+        "hash": {
+            "url": "$url.sha256"
+        }
+    }
+}

--- a/bucket/wezterm.json
+++ b/bucket/wezterm.json
@@ -26,12 +26,12 @@
     ],
     "checkver": {
         "github": "https://github.com/ocodo/wezterm-alt-windows-icon-builds",
-        "regex": "wezterm-Mikker-Black-([\\w-]+)"
+        "regex": "tag/(([\\w-]+)-alt-icons)"
     },
     "autoupdate": {
         "architecture": {
             "64bit": {
-                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Mikker-Black-$version.zip"
+                "url": "https://github.com/ocodo/wezterm-alt-windows-icon-builds/releases/download/$version/WezTerm-windows-Mikker-Black-$match1.zip"
             }
         },
         "hash": {


### PR DESCRIPTION
## Overview

This is the first PR in a three-part stack to integrate scoop bucket. With this PR, all scoop commands should start working.

This PR introduces:
- the `bucket/` dir, which contains manifest files that used by scoop commands.
- update to the instruction of scoop command in README.md

## Details

The fields 'version', 'url', and 'regex' are tied to the tag names in this repo. Note that 'regex' field will capture both:

- version number (e.g '20240203-110809-5046fc22'), and 
- entire tag version (e.g '20240203-110809-5046fc22-alt-icons') 

to construct new 'url' field when auto updating.

In addition, the fields 'notes', 'url' and 'shortcuts' are tied to the artist and each icon theme.
