### PR TITLE
PR: Add Local Testing Script for Integration of Scoop Bucket

### DIFF
--- a/.github/workflows/scoop-ci.yml
+++ b/.github/workflows/scoop-ci.yml
@@ -1,0 +1,59 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - 'main'
+      - 'master'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test_powershell:
+    name: WindowsPowerShell
+    runs-on: windows-latest
+    steps:
+      - name: Checkout Bucket
+        uses: actions/checkout@main
+        with:
+          fetch-depth: 2
+          path: my_bucket
+      - name: Checkout Scoop
+        uses: actions/checkout@main
+        with:
+          repository: ScoopInstaller/Scoop
+          path: scoop_core
+      - name: Init Test Suite
+        uses: potatoqualitee/psmodulecache@main
+        with:
+          modules-to-cache: BuildHelpers
+          shell: powershell
+      - name: Test Bucket
+        shell: powershell
+        run: |
+          $env:SCOOP_HOME="$(Convert-Path '.\scoop_core')"
+          .\my_bucket\bin\test.ps1
+  test_pwsh:
+    name: PowerShell
+    runs-on: windows-latest
+    steps:
+      - name: Checkout Bucket
+        uses: actions/checkout@main
+        with:
+          fetch-depth: 2
+          path: my_bucket
+      - name: Checkout Scoop
+        uses: actions/checkout@main
+        with:
+          repository: ScoopInstaller/Scoop
+          path: scoop_core
+      - name: Init Test Suite
+        uses: potatoqualitee/psmodulecache@main
+        with:
+          modules-to-cache: BuildHelpers
+          shell: pwsh
+      - name: Test Bucket
+        shell: pwsh
+        run: |
+          $env:SCOOP_HOME="$(Convert-Path '.\scoop_core')"
+          .\my_bucket\bin\test.ps1

--- a/.github/workflows/scoop-ci.yml
+++ b/.github/workflows/scoop-ci.yml
@@ -1,11 +1,14 @@
-name: Tests
+name: Tests for scoop bucket
 
 on:
   push:
     branches:
-      - 'main'
-      - 'master'
+      - "main"
+    paths:
+      - "bucket/*.json"
   pull_request:
+    paths:
+      - "bucket/*.json"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/scoop-excavator.yml
+++ b/.github/workflows/scoop-excavator.yml
@@ -1,0 +1,17 @@
+on:
+  workflow_dispatch:
+  schedule:
+    # run every 4 hours
+    - cron: '20 */4 * * *'
+name: Excavator
+jobs:
+  excavate:
+    name: Excavate
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@main
+      - name: Excavate
+        uses: ScoopInstaller/GithubActions@main
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SKIP_UPDATED: 1

--- a/.github/workflows/scoop-excavator.yml
+++ b/.github/workflows/scoop-excavator.yml
@@ -1,9 +1,11 @@
+name: Excavator for scoop bucket
+
 on:
   workflow_dispatch:
   schedule:
     # run every 4 hours
-    - cron: '20 */4 * * *'
-name: Excavator
+    - cron: "20 */4 * * *"
+
 jobs:
   excavate:
     name: Excavate

--- a/Scoop-Bucket.Tests.ps1
+++ b/Scoop-Bucket.Tests.ps1
@@ -1,0 +1,7 @@
+if (!$env:SCOOP_HOME) { $env:SCOOP_HOME = Resolve-Path (scoop prefix scoop) }
+
+# Determine the path to the bucket directory
+$bucketPath = Resolve-Path "$PSScriptRoot\bucket"
+
+# Import the core test script and pass the bucket path
+. "$env:SCOOP_HOME\test\Import-Bucket-Tests.ps1" -BucketPath $bucketPath

--- a/bin/auto-pr.ps1
+++ b/bin/auto-pr.ps1
@@ -1,8 +1,8 @@
-# this tells the auto-pr script which upstream repository to create pull requests against when automated updates are found by checkver.ps1.
+# local wrapper for manual testing, and it delegates to Scoop's binary after resolving path
 
 param(
     # overwrite upstream param
-    [String]$upstream = "noidilin/wezterm-alt-icon:master"
+    [String]$upstream = "ocodo/wezterm-alt-windows-icon-builds:main"
 )
 
 if (!$env:SCOOP_HOME) { $env:SCOOP_HOME = Convert-Path (scoop prefix scoop) }

--- a/bin/auto-pr.ps1
+++ b/bin/auto-pr.ps1
@@ -1,0 +1,11 @@
+# this tells the auto-pr script which upstream repository to create pull requests against when automated updates are found by checkver.ps1.
+
+param(
+    # overwrite upstream param
+    [String]$upstream = "noidilin/wezterm-alt-icon:master"
+)
+
+if (!$env:SCOOP_HOME) { $env:SCOOP_HOME = Convert-Path (scoop prefix scoop) }
+$autopr = "$env:SCOOP_HOME/bin/auto-pr.ps1"
+$dir = "$PSScriptRoot/../bucket" # checks the parent dir
+& $autopr -Dir $dir -Upstream $Upstream @Args

--- a/bin/checkhashes.ps1
+++ b/bin/checkhashes.ps1
@@ -1,0 +1,4 @@
+if (!$env:SCOOP_HOME) { $env:SCOOP_HOME = Convert-Path (scoop prefix scoop) }
+$checkhashes = "$env:SCOOP_HOME/bin/checkhashes.ps1"
+$dir = "$PSScriptRoot/../bucket" # checks the parent dir
+& $checkhashes -Dir $dir @Args

--- a/bin/checkurls.ps1
+++ b/bin/checkurls.ps1
@@ -1,0 +1,4 @@
+if (!$env:SCOOP_HOME) { $env:SCOOP_HOME = Convert-Path (scoop prefix scoop) }
+$checkurls = "$env:SCOOP_HOME/bin/checkurls.ps1"
+$dir = "$PSScriptRoot/../bucket" # checks the parent dir
+& $checkurls -Dir $dir @Args

--- a/bin/checkver.ps1
+++ b/bin/checkver.ps1
@@ -1,0 +1,4 @@
+if (!$env:SCOOP_HOME) { $env:SCOOP_HOME = Convert-Path (scoop prefix scoop) }
+$checkver = "$env:SCOOP_HOME/bin/checkver.ps1"
+$dir = "$PSScriptRoot/../bucket" # checks the parent dir
+& $checkver -Dir $dir @Args

--- a/bin/formatjson.ps1
+++ b/bin/formatjson.ps1
@@ -1,0 +1,4 @@
+if (!$env:SCOOP_HOME) { $env:SCOOP_HOME = Convert-Path (scoop prefix scoop) }
+$formatjson = "$env:SCOOP_HOME/bin/formatjson.ps1"
+$path = "$PSScriptRoot/../bucket" # checks the parent dir
+& $formatjson -Dir $path @Args

--- a/bin/missing-checkver.ps1
+++ b/bin/missing-checkver.ps1
@@ -1,0 +1,4 @@
+if (!$env:SCOOP_HOME) { $env:SCOOP_HOME = Convert-Path (scoop prefix scoop) }
+$missing_checkver = "$env:SCOOP_HOME/bin/missing-checkver.ps1"
+$dir = "$PSScriptRoot/../bucket" # checks the parent dir
+& $missing_checkver -Dir $dir @Args

--- a/bin/test.ps1
+++ b/bin/test.ps1
@@ -1,0 +1,15 @@
+#Requires -Version 5.1
+#Requires -Modules @{ ModuleName = 'BuildHelpers'; ModuleVersion = '2.0.1' }
+#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '5.2.0' }
+
+$pesterConfig = New-PesterConfiguration -Hashtable @{
+    Run    = @{
+        Path     = "$PSScriptRoot/.."
+        PassThru = $true
+    }
+    Output = @{
+        Verbosity = 'Detailed'
+    }
+}
+$result = Invoke-Pester -Configuration $pesterConfig
+exit $result.FailedCount


### PR DESCRIPTION
## Overview

(Depends on #3)

This is the second PR in a three-part stack to integrate scoop bucket. With this PR, manifest files can be tested with scripts provided in [ScoopInstaller/BucketTemplate](https://github.com/ScoopInstaller/BucketTemplate).

This PR introduces:

- pwsh scripts in `bin/` dir
- pester test script at `./Scoop-Bucket.Tests.ps1`

(The only change to the original template in this PR is within `./bin/auto-pr.ps1` and `./Scoop-Bucket.Tests.ps1`)

## Details

These are thin wrappers for [core scoop's utilities](https://github.com/ScoopInstaller/Scoop/tree/master/bin), which locate at scoop's installation while targeting the `bucket/` directory. 

- `checkver.ps1`: scans manifests for new versions based on checkver properties.
  - It can auto update manifests with new versions.
- `checkhashes.ps1`: validates that SHA256 hashes in manifests match actual downloaded files.
  - It can auto update manifest with correct hashes when mismatches are found.
- `checkurls.ps1`: checks that all URLs in manifests are accessible and return valid responses.
- `missing-checkver.ps1`: identifies manifests missing `checkver` or `autoupdate` properties.
- `formatjson.ps1`: formats manifest JSON files with consistent 4 space indentation and pretty printing.
- `auto-pr.ps1`: automated workflow that runs checkver, commits changes, and either pushes directly to origin or creates pull requests to upstream.
  - **CHANGED:** set upstream to `ocodo/wezterm-alt-windows-icon-builds:main` before delegates to Scoop's utilities

> [!NOTE]
> The command `scoop prefix scoop` in wrapper scripts will output the installation directory of scoop.

These are the main test runner using Pester 5.2.0+. 

- `test.ps1`: excutes `Scoop-Bucket.Tests.ps1` with pester config and output detailed verbosity and failure count for CI/CD integration.
- `Scoop-Bucket.Tests.ps1`: execute core Scoop's `Import-Bucket-Tests.ps1` with passed in config. (see also: https://github.com/ScoopInstaller/Scoop/blob/master/test/Import-Bucket-Tests.ps1)
  - **CHANGED:** limit the range being tested in `bucket/` dir
